### PR TITLE
Added About page and respective links in header and footer

### DIFF
--- a/pyconpune/staticfiles/css/main.css
+++ b/pyconpune/staticfiles/css/main.css
@@ -106,7 +106,7 @@
 .footer-block {
     display: inline-block;
     vertical-align: top;
-    padding: 20px;    
+    padding: 20px;
     font-size: 12px;
     opacity: 0.6;
 }
@@ -218,6 +218,24 @@
       -moz-transition: all .3s;
       transition: all .3s;
   }
+
+.no-borders{
+    border-radius: 0px;
+}
+
+.google-maps {
+        position: relative;
+        padding-bottom: 75%; // This is the aspect ratio
+        height: 0;
+        overflow: hidden;
+}
+    .google-maps iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100% !important;
+        height: 100% !important;
+    }
 
 /* Responsive Design (Starts) */
 /* For mobiles */

--- a/pyconpune/templates/about.html
+++ b/pyconpune/templates/about.html
@@ -1,0 +1,124 @@
+{% extends 'site_base.html' %}
+{% load staticfiles %}
+
+{% block body %}
+    <!-- About PyCon section -->
+    <section class="no-margin section-padding float-left full-width" id="about_pycon">
+        <div class="full-width">
+            <div class="col-960 col-center full-height">
+                <div>
+                    <h2>About PyCon</h2>
+                    <p class="standard-margin-top">
+                        PyCon, the gathering for the community using and developing
+                the open-source Python programming language. During PyCon Pune, the community will meet for two days of talks and work on upstream projects in two days of dev sprint.
+                    </p>
+                </div>
+                <div class="schedule-block">
+                    <div class="gray-bg">
+                        <p class="schedule-date">8-9</p>
+                        <p class="schedule-month blue-bg text-white">February</p>
+                    </div>
+                    <div>
+                        <p class="schedule-heading">Talk</p>
+                        <p class="schedule-brief">Dozens of talks chosen by the community</p>
+                    </div>
+                </div>
+                <div class="schedule-block">
+                    <div class="gray-bg">
+                        <p class="schedule-date">10-11</p>
+                        <p class="schedule-month blue-bg text-white">February</p>
+                    </div>
+                    <div>
+                        <p class="schedule-heading">Dev Sprint</p>
+                        <p class="schedule-brief">Team up to work on upstream projects</p>
+                    </div>
+                </div>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+        <!--<div class="about-section-image" style="background-image: url(https://s-media-cache-ak0.pinimg.com/736x/94/26/d9/9426d98a6604fe95f68258963427dc24&#45;&#45;flower-line-drawings-line-drawing-floral.jpg' %})"></div>-->
+    </section>
+
+    <!-- About Pune section -->
+    <section class="no-margin section-padding gray-bg float-left full-width" id="about_pune">
+        <div class="full-width">
+            <div class="col-960 col-center full-height">
+                <div>
+                    <h2>About Pune</h2>
+                    <p class="standard-margin-top">
+                        Pune, also called Poona, city, west-central Maharashtra state, western India, at the junction of the Mula and Mutha rivers. Called “Queen of the Deccan”. Pune has long been a major educational and cultural centre; former prime minister Jawaharlal Nehru referred to it as the “Oxford and Cambridge of India”.
+                    </p>
+                </div>
+
+                <div>
+                    <h2>Places to see near Pune</h2>
+                    <div class="row">
+                        <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
+                            <div class="thumbnail gray-bg no-borders">
+                                <a href="https://www.holidify.com/places/pune/aga-khan-palace-sightseeing-3297.html">
+                                    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Pune_Palace.jpg/1200px-Pune_Palace.jpg" alt="Aga Khan Palace" style="width:100%">
+                                    <div class="caption">
+                                        <h4 class="text-center">Aga Khan Palace</h4>
+                                        <p>
+                                            Aga Khan Palace is well known both for its architectural excellence as well as its historical significance. Spread over a vast land of 19 acres, the palace is now the headquarters of the Gandhi National memorial society.
+                                        </p>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+
+                        <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
+                            <div class="thumbnail gray-bg no-borders">
+                                <a href="https://www.holidify.com/places/pune/shaniwar-wada-sightseeing-3313.html">
+                                    <img src="http://3.bp.blogspot.com/-sGlFeg8y6wg/VPBVUb3Ds1I/AAAAAAAAAqY/1GSg8HDXOmM/s1600/Shaniwar%2BWada%2Bentry%2Bgate.jpg" alt="Shaniwar Wada" style="width:100%">
+                                    <div class="caption">
+                                        <h4 class="text-center">Shaniwar Wada</h4>
+                                        <p>
+                                            Standing tall in its full glory, Shaniwar Wada was once a stately mansion. Built as a dwelling for Peshwas, its foundation was laid by Bajirao I in year 1730 AD. Today it gives a chance to peak into its great past.
+                                        </p>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+
+                        <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
+                            <div class="thumbnail gray-bg no-borders">
+                                <a href="https://www.holidify.com/places/pune/osho-ashram-sightseeing-3307.html">
+                                    <img src="http://img1.holidayiq.com/images/attractions/Osho_Ashram_Pune_9736.jpg" alt="Osho Ashram" style="width:100%">
+                                    <div class="caption">
+                                        <h4 class="text-center">Osho Ashram</h4>
+                                        <p>
+                                            It's a tranquil place which brings you to you own centers of peace and meditation. The ideologies of Osho also can be found here. This is a wonderful place to hunt for the meaning we tend to look for in our everyday lives.
+                                        </p>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <div class="clearfix"></div>
+        </div>
+    </section>
+
+    <!-- About PyCon section -->
+    <section class="no-margin section-padding float-left full-width" id="about_pycon">
+        <div class="full-width">
+            <div class="col-960 col-center full-height">
+                <div>
+                    <h2>Venue</h2>
+                    <p class="standard-margin-top">
+                        Amanora The Fern Hotels and Club
+                        This palatial hotel with a columned facade, sprawling grounds and a lake is 9 km from Aga Khan Palace, an 1892 landmark honouring Gandhi. Pune Airport is 11 km away.
+                        Haute rooms with balconies feature flat-screens, minibars and tea and coffeemaking facilities; upgraded rooms add free Wi-Fi. Suites have separate living rooms and exclusive lounge access. Room service is offered 24/7.
+                    </p>
+                </div>
+
+                <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 google-maps
+                ">
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3783.237602016919!2d73.93952795009344!3d18.518161987348577!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bc2c22161862853%3A0x5ed70272d869e104!2sAmanora+The+Fern+Hotels+and+Club!5e0!3m2!1sen!2sin!4v1500404348864" frameborder="0" style="border:0" allowfullscreen></iframe>
+                </div>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+    </section>
+{% endblock %}

--- a/pyconpune/templates/site_base.html
+++ b/pyconpune/templates/site_base.html
@@ -47,7 +47,7 @@
             <div class="mobile-only mobile-menu-btn"></div>
             <img class="logo float-left" src='{% static "img/logo.png" %}' />
             <ul class="nav-menu">
-                <li><a href="{% url 'homepage' %}#about">About</a></li>
+                <li><a href="{% url 'about' %}">About</a></li>
                 <li><a href="{% url 'coc' %}">CoC</a></li>
                 <!-- <li><a href="#">Schedule</a></li> -->
                 <!--<li><a href="#">Venue</a></li>-->
@@ -92,7 +92,9 @@
                             </div>
                             <div class="footer-block">
                                 <div class="bold caps">Venue</div>
-                                <div>About Pune & Venue</div>
+                                <a href="{% url 'about' %}">
+                                   <div>About Pune & Venue</div>
+                                </a>
                                 <div>Travelling to Pune</div>
                                 <div>Accessibility</div>
                             </div>
@@ -109,7 +111,7 @@
                         </div>
                     </div>
                     <div class="map">
-                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3783.237602016919!2d73.93952795009344!3d18.518161987348577!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bc2c22161862853%3A0x5ed70272d869e104!2sAmanora+The+Fern+Hotels+and+Club!5e0!3m2!1sen!2sin!4v1500404348864" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>      
+                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3783.237602016919!2d73.93952795009344!3d18.518161987348577!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bc2c22161862853%3A0x5ed70272d869e104!2sAmanora+The+Fern+Hotels+and+Club!5e0!3m2!1sen!2sin!4v1500404348864" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
                     </div>
                 </div>
 

--- a/root/urls.py
+++ b/root/urls.py
@@ -9,7 +9,9 @@ urlpatterns = [
         url(r'^$', root.views.homepage,
             name="homepage"),
         url(r'^coc/$', root.views.coc,
-            name="coc")
+            name="coc"),
+        url(r'^about/$', root.views.about,
+            name="about")
     ]))
 ]
 

--- a/root/views.py
+++ b/root/views.py
@@ -3,8 +3,14 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect
 
+
 def homepage(request):
     return render(request, template_name='index.html', context={'page': 'home'})
 
+
 def coc(request):
     return render(request, template_name='coc.html', context={'page': 'coc'})
+
+
+def about(request):
+    return render(request, 'about.html', context={'page': 'about'})


### PR DESCRIPTION
Added following contents in static '**about**' page

About PyCon section:

![aboutpycon](https://user-images.githubusercontent.com/17998893/30529917-e3632964-9c5f-11e7-98a9-2d06d86de3a4.png)

About Pune and places to visit section:

![aboutpune](https://user-images.githubusercontent.com/17998893/30529925-f6c8f268-9c5f-11e7-9c3b-c7d15a777227.png)

Venue details and full-width map:

![venue](https://user-images.githubusercontent.com/17998893/30529931-033a5442-9c60-11e7-99a2-afee0723d391.png)
