### PR TITLE
Added Sponsors static page with updated header and footer links

### DIFF
--- a/pyconpune/templates/site_base.html
+++ b/pyconpune/templates/site_base.html
@@ -56,7 +56,7 @@
                 <!--<li><a href="#">Registration</a></li>-->
                 <li><a href="{% url 'homepage' %}#speakers">Speakers</a></li>
                 <li><a href="https://pyconpune.talkfunnel.com/2018/" target="_blank" rel="noopener noreferrer">CFP</a></li>
-                <li><a href="{% url 'homepage' %}#sponsor">Sponsors</a></li>
+                <li><a href="{% url 'sponsors' %}">Sponsors</a></li>
                 <li>
                     <a href="#" class="hide inline-block">
                         <button class="btn btn-primary buy-tickets-btn">Buy Tickets</button>
@@ -102,7 +102,9 @@
                             </div>
                             <div class="footer-block">
                                 <div class="bold caps">Be A</div>
-                                <div>Be a Sponsor</div>
+                                <a href="{% url 'sponsors' %}">
+                                    <div> Be a Sponsor</div>
+                                </a>
                                 <a href="{% url 'volunteer' %}">
                                     <div> Be a Volunteer</div>
                                 </a>

--- a/pyconpune/templates/sponsors.html
+++ b/pyconpune/templates/sponsors.html
@@ -23,20 +23,16 @@
                 </div>
 
                 <div class="section-padding col-lg-12 col-md-12 col-sm-12 col-xs-12">
-                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
                         <img src="{% static 'img/RedHat.png' %}" alt="Redhat Logo" class="img-responsive">
                     </div>
 
-                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12 img-margin-top">
                         <img src="{% static 'img/psf.png' %}" alt="PSF Logo" class="img-responsive">
                     </div>
 
-                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
                         <img src="{% static 'img/travisci.png' %}" alt="Travis Logo" class="img-responsive">
-                    </div>
-
-                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
-                        <img src="{% static 'img/RedHat.png' %}" alt="Redhat Logo" class="img-responsive">
                     </div>
                 </div>
             </div>

--- a/pyconpune/templates/sponsors.html
+++ b/pyconpune/templates/sponsors.html
@@ -1,0 +1,46 @@
+{% extends 'site_base.html' %}
+{% load staticfiles %}
+
+{% block body %}
+    <!-- Sponsor Section -->
+    <section class="no-margin section-padding float-left full-width" id="sponsors">
+        <div class="full-width">
+            <div class="col-960 col-center full-height">
+                <div>
+                    <h2>Sponsors</h2>
+                    <p class="standard-margin-top">
+                        PyCon Pune is entirely driven by volunteers. Sponsoring the
+                        event helps to sustain, grow the conference along with the
+                        community. Sponsors help to make the conference affordable for
+                        community, and maintaining the inventory for the
+                        conference.
+                    </p>
+                </div>
+                <div class="align-center">
+                    <a href="mailto:pyconpune@python.org?subject=Sponsor for PyCon Pune 2018" class="inline-block standard-margin-top">
+                        <button class="btn btn-primary buy-tickets-btn">Become a Sponsor</button>
+                    </a>
+                </div>
+
+                <div class="section-padding col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                        <img src="{% static 'img/RedHat.png' %}" alt="Redhat Logo" class="img-responsive">
+                    </div>
+
+                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                        <img src="{% static 'img/psf.png' %}" alt="PSF Logo" class="img-responsive">
+                    </div>
+
+                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                        <img src="{% static 'img/travisci.png' %}" alt="Travis Logo" class="img-responsive">
+                    </div>
+
+                    <div class="col-lg-3 col-md-3 col-sm-12 col-xs-12">
+                        <img src="{% static 'img/RedHat.png' %}" alt="Redhat Logo" class="img-responsive">
+                    </div>
+                </div>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+    </section>
+{% endblock %}

--- a/root/urls.py
+++ b/root/urls.py
@@ -13,7 +13,9 @@ urlpatterns = [
         url(r'^volunteer/$', root.views.volunteer,
             name="volunteer"),
         url(r'^about/$', root.views.about,
-            name="about")
+            name="about"),
+        url(r'^sponsors/$', root.views.sponsors,
+            name="sponsors")
     ]))
 ]
 

--- a/root/views.py
+++ b/root/views.py
@@ -6,9 +6,11 @@ from django.http import HttpResponse, HttpResponseRedirect
 
 def homepage(request):
     return render(request, template_name='index.html', context={'page': 'home'})
-    
+
+
 def coc(request):
     return render(request, template_name='coc.html', context={'page': 'coc'})
+
 
 def volunteer(request):
     # Dummy List of Volunteers, will be fetched from DB later
@@ -42,5 +44,10 @@ def volunteer(request):
     return render(request, template_name='volunteer.html',
                 context={'page': 'volunteer', 'volunteer_list': list_of_volunteers })
 
+
 def about(request):
     return render(request, 'about.html', context={'page': 'about'})
+
+
+def sponsors(request):
+    return render(request, 'sponsors.html', context={'page': 'about'})


### PR DESCRIPTION
I have added the static page for Sponsors. As @SaptakS said, four sponsors in a row are aligned with responsive images.

Here's the screenshot for the same:

![sponsors](https://user-images.githubusercontent.com/17998893/30772800-c9c5c488-a080-11e7-82d6-058ba75390b6.png)

Fixed #57 